### PR TITLE
Add MediaWiki/listpages via iterator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .env
 __pycache__
+.venv

--- a/ingestion/mediawiki_api/mediawiki_api.py
+++ b/ingestion/mediawiki_api/mediawiki_api.py
@@ -2,8 +2,6 @@ import concurrent.futures
 from concurrent.futures import Future
 import requests
 
-#TODO: 
-
 class MediaWikiAPI:
     def __init__(self) -> None:
         self.url = "https://en.wikipedia.org/w/api.php"

--- a/ingestion/mediawiki_api/mediawiki_api.py
+++ b/ingestion/mediawiki_api/mediawiki_api.py
@@ -1,0 +1,41 @@
+import concurrent.futures
+from concurrent.futures import Future
+import requests
+
+class EndOfPageListException(Exception):
+    def __init__(self, final_page_list: list[str]) -> None:
+        self.final_page_list = final_page_list
+
+class MediaWikiAPI:
+    def __init__(self) -> None:
+        self.url = "https://en.wikipedia.org/w/api.php"
+        self.headers = {
+            "User-Agent": "Pliny test",
+            "From": "wolf.vandierdonck@gmail.com",
+        }
+        self.executor = concurrent.futures.ThreadPoolExecutor(max_workers=100)
+    
+    def get_all_pages_starting_from(self, page_name: str) -> Future[tuple[list[str], str]]:
+        def fetch_and_process(page_name: str) -> tuple[list[str], str]:
+            params = {
+                "action": "query",
+                "format": "json",
+                "list": "allpages",
+                "apfrom": page_name,
+                "aplimit": "500",
+            }
+            response = requests.get(self.url, headers=self.headers, params=params)
+            data = response.json()
+
+            if "query" not in data or "allpages" not in data["query"]:
+                raise ValueError(f"Unexpected response: {data}")
+
+            if "continue" not in data:
+                raise EndOfPageListException([page["title"] for page in data["query"]["allpages"]])
+
+            pages = data["query"]["allpages"]
+            page_to_continue_from: str = data["continue"]["apcontinue"]
+            page_names: list[str] = [page["title"] for page in pages]
+            return (page_names, page_to_continue_from)
+            
+        return self.executor.submit(fetch_and_process, page_name)

--- a/ingestion/mediawiki_api/mediawiki_helper.py
+++ b/ingestion/mediawiki_api/mediawiki_helper.py
@@ -1,0 +1,44 @@
+from ingestion.mediawiki_api.mediawiki_api import MediaWikiAPI
+
+
+class MediaWikiPageListIterator:
+    def __init__(self, start_char: str) -> None:
+        self.cache: list[str] = []
+        self.cache_index = 0
+        self.current_char = start_char
+
+        self.media_wiki_api = MediaWikiAPI()
+        self.fetching_future = self.media_wiki_api.get_all_pages_starting_from(self.current_char)
+    
+    def __next__(self) -> str:
+        # if our cache has been exhausted
+        if self.cache_index == len(self.cache):
+            # wait for the fetching future to complete and immediately start the next fetch
+            future_result = self.fetching_future.result()
+            #populate cache
+            self.cache = future_result
+            #get where to continue from
+            #immediately make async request for next batch
+
+            self.fetching_future = self.media_wiki_api.get_all_pages_starting_from(self.current_char)
+            
+
+
+        if (self.cache_index < len(self.cache)):
+            self.cache_index += 1
+            return self.cache[self.cache_index - 1]
+        
+        if self.fetching_future is None:
+            self.fetching_future = MediaWikiAPI.get_all_pages_starting_from(self.current_char)
+        # Otherwise, fetch the next batch
+        if self.current_char == "z":
+            raise StopIteration
+        return selfself.cache[self.cache_index]
+
+class MediaWikiHelper:
+    def __init__(self) -> None:
+        pass
+
+    @staticmethod
+    def get_all_pages_iterator() -> MediaWikiPageListIterator:
+        return MediaWikiPageListIterator("a")

--- a/ingestion/mediawiki_api/mediawiki_helper.py
+++ b/ingestion/mediawiki_api/mediawiki_helper.py
@@ -1,39 +1,35 @@
-from ingestion.mediawiki_api.mediawiki_api import MediaWikiAPI
+from ingestion.mediawiki_api.mediawiki_api import  MediaWikiAPI
 
 
 class MediaWikiPageListIterator:
-    def __init__(self, start_char: str) -> None:
+    def __init__(self, start_page: str) -> None:
         self.cache: list[str] = []
         self.cache_index = 0
-        self.current_char = start_char
+        self.page_to_fetch: str | None = start_page
 
         self.media_wiki_api = MediaWikiAPI()
-        self.fetching_future = self.media_wiki_api.get_all_pages_starting_from(self.current_char)
+        self.fetching_future = self.media_wiki_api.get_all_pages_starting_from(self.page_to_fetch)
     
     def __next__(self) -> str:
-        # if our cache has been exhausted
+        # if our cache has been exhausted, wait for fetching future and fetch next batch
         if self.cache_index == len(self.cache):
-            # wait for the fetching future to complete and immediately start the next fetch
+            if self.page_to_fetch == None:       #cache empty and no new future
+                raise StopIteration
+
+            self.cache_index = 0
             future_result = self.fetching_future.result()
             #populate cache
-            self.cache = future_result
+            self.cache = future_result[0]
             #get where to continue from
+            self.page_to_fetch = future_result[1]
             #immediately make async request for next batch
+            if self.page_to_fetch is not None:
+                self.fetching_future = self.media_wiki_api.get_all_pages_starting_from(self.page_to_fetch)
 
-            self.fetching_future = self.media_wiki_api.get_all_pages_starting_from(self.current_char)
-            
-
-
-        if (self.cache_index < len(self.cache)):
-            self.cache_index += 1
-            return self.cache[self.cache_index - 1]
-        
-        if self.fetching_future is None:
-            self.fetching_future = MediaWikiAPI.get_all_pages_starting_from(self.current_char)
-        # Otherwise, fetch the next batch
-        if self.current_char == "z":
-            raise StopIteration
-        return selfself.cache[self.cache_index]
+        # return next page from cache
+        cached_page = self.cache[self.cache_index]
+        self.cache_index += 1
+        return cached_page
 
 class MediaWikiHelper:
     def __init__(self) -> None:
@@ -41,4 +37,4 @@ class MediaWikiHelper:
 
     @staticmethod
     def get_all_pages_iterator() -> MediaWikiPageListIterator:
-        return MediaWikiPageListIterator("a")
+        return MediaWikiPageListIterator("!")

--- a/ingestion/wikimedia_api/wikimedia_api.py
+++ b/ingestion/wikimedia_api/wikimedia_api.py
@@ -4,7 +4,7 @@ import concurrent.futures
 from concurrent.futures import Future
 
 
-class WikimediaApi:
+class WikiMediaApi:
     def __init__(self) -> None:
         self.project = "wikipedia"
         self.language = "en"

--- a/main.py
+++ b/main.py
@@ -1,7 +1,6 @@
 from dotenv import load_dotenv
 from common.dates import Date, DateRange
 from common.time_series import TimeSeries
-from ingestion.mediawiki_api.mediawiki_api import MediaWikiAPI
 from ingestion.mediawiki_api.mediawiki_helper import MediaWikiHelper
 from ingestion.processor.basic_processor import BasicProcessor
 import random

--- a/main.py
+++ b/main.py
@@ -10,6 +10,12 @@ import experimentation.sample_articles
 
 load_dotenv(dotenv_path=".env")
 
+page_iterator = MediaWikiHelper.get_all_pages_iterator()
+for i in range(100):
+    next_page = next(page_iterator)
+    print(next_page)
+exit()
+
 sample_articles = experimentation.sample_articles.early_august_articles
 
 # Take 100 random articles to process
@@ -17,25 +23,6 @@ NUM_PAGES = 100
 pages_to_process = random.sample(
     list(sample_articles), min(NUM_PAGES, len(sample_articles))
 )
-
-#get all pages from a
-media_wiki = MediaWikiAPI()
-starting_word = "z"
-while True: 
-    pages, starting_word = media_wiki.get_all_pages_starting_from(starting_word).result()
-    print(pages)
-
-
-
-# page_iterator = MediaWikiHelper.get_all_pages_iterator()
-# try:
-#     for i in range(100):
-#         next_page = next(page_iterator)
-#         print(next_page)
-# except StopIteration:
-#     pass
-
-# exit()
 
 date_range = DateRange(Date(2024, 8, 5), Date(2024, 8, 8))
 

--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 from dotenv import load_dotenv
 from common.dates import Date, DateRange
 from common.time_series import TimeSeries
+from ingestion.mediawiki_api.mediawiki_api import MediaWikiAPI
+from ingestion.mediawiki_api.mediawiki_helper import MediaWikiHelper
 from ingestion.processor.basic_processor import BasicProcessor
 import random
 from scoring.scorer.basic_scorer import BasicScorer
@@ -15,6 +17,25 @@ NUM_PAGES = 100
 pages_to_process = random.sample(
     list(sample_articles), min(NUM_PAGES, len(sample_articles))
 )
+
+#get all pages from a
+media_wiki = MediaWikiAPI()
+starting_word = "z"
+while True: 
+    pages, starting_word = media_wiki.get_all_pages_starting_from(starting_word).result()
+    print(pages)
+
+
+
+# page_iterator = MediaWikiHelper.get_all_pages_iterator()
+# try:
+#     for i in range(100):
+#         next_page = next(page_iterator)
+#         print(next_page)
+# except StopIteration:
+#     pass
+
+# exit()
 
 date_range = DateRange(Date(2024, 8, 5), Date(2024, 8, 8))
 


### PR DESCRIPTION
Create MediaWiki API wrapper.

- currently wraps list:allpages endpoint
- interact with all pages through `MediaWikiPageListIterator`
- iterator is fetched using the MediaWikiHelper

