### PR TITLE
fix: why download randomly stops

### DIFF
--- a/data-pipeline/ingestion/processor/intermediate_table_processor.py
+++ b/data-pipeline/ingestion/processor/intermediate_table_processor.py
@@ -1,4 +1,3 @@
-import concurrent.futures
 from common.dates import Date
 from sql.wikipedia_data_accessor import WikipediaDataAccessor
 from sql.intermediate_table_data import IntermediateTableRow

--- a/data-pipeline/ingestion/processor/intermediate_table_processor.py
+++ b/data-pipeline/ingestion/processor/intermediate_table_processor.py
@@ -34,11 +34,8 @@ class IntermediateTableProcessor:
             page: IntermediateTableRow(page) for page in pages
         }
 
-        for view_future in concurrent.futures.as_completed(view_futures.values()):
+        for page, view_future in view_futures.items():
             try:
-                page = next(
-                    page for page, f in view_futures.items() if f == view_future
-                )
                 views = view_future.result()
                 data[page].view_count = views
             except Exception as e:
@@ -46,14 +43,8 @@ class IntermediateTableProcessor:
                     f"Error processing view future for page {page}: {e}", Component.CORE
                 )
 
-        for revision_future in concurrent.futures.as_completed(
-            revision_futures.values()
-        ):
+        for page, revision_future in revision_futures.items():
             try:
-                # Retrieve the input (page) from the dictionary
-                page = next(
-                    page for page, f in revision_futures.items() if f == revision_future
-                )
                 revision_metadata = revision_future.result()
                 data[page].revision_count = revision_metadata.revision_count
                 data[page].editor_count = revision_metadata.editor_count

--- a/data-pipeline/ingestion/wikimedia_dumps/dump_manager.py
+++ b/data-pipeline/ingestion/wikimedia_dumps/dump_manager.py
@@ -65,7 +65,7 @@ class DumpManager:
                 and next_day not in self.dumps_downloaded
             ):
                 self.dumps_downloaded[next_day] = self.executor.submit(
-                    self.get_page_view_dump_filename, next_day
+                    download_page, next_day
                 )
             return f"dumps/pageviews-{date.year}{date.month:02}{date.day:02}-user"
 

--- a/data-pipeline/main.py
+++ b/data-pipeline/main.py
@@ -21,7 +21,7 @@ BATCH_WAIT_TIME = 0.0
 logger = Logger("data-pipeline")
 
 wikipedia_data_accessor = WikipediaDataAccessor(
-    logger, "PLINY_BIGQUERY_SERVICE_ACCOUNT", buffer_size=100000
+    logger, "PLINY_BIGQUERY_SERVICE_ACCOUNT", buffer_size=1000000
 )
 # wikipedia_data_accessor.delete_table("intermediate_table")
 # wikipedia_data_accessor.create_table("intermediate_table", INTEMEDIATE_TABLE_SCHEMA)


### PR DESCRIPTION
(needs to be tested, i will do so)

what I think was happening:

when we prefetch the next day,
```python
# pre-fetch next day's data, self-recursive
            next_day = date.add_days(1)
            if (
                next_day <= self.date_range.end
                and next_day not in self.dumps_downloaded
            ):
                self.dumps_downloaded[next_day] = self.executor.submit(
                    self.get_page_view_dump_filename, next_day
                )
            return f"dumps/pageviews-{date.year}{date.month:02}{date.day:02}-user"

```

we would call on `self.get_page_view_dump_filename` which checks for whether a future exists for the date

```python

    def get_page_view_dump_filename(self, date: Date) -> str:
        if date not in self.dumps_downloaded:
            # typically this doesn't run, only if out of sequence
            self.dumps_downloaded[date] = self.download_page_view_dump(date)
        return self.dumps_downloaded[date].result()
```

so if the task submitted to the executor runs before it is assigned to `self.dumps_downloaded[next_day]` in the prefetch, the call to `get_page_view_dump_filename` would successfully trigger a download and wait on it, the future returned in the prefetch would then just be a future that waits on the result of the inner future (the actual download) to finish.

if the future is assigned before the task is run, then when the task runs, `date not in self.dumps_downloaded` will be false  and it will wait on  self.dumps_downloaded[date].result() which is itself...

this change actually downloads the page during our prefetch, which might be what we should've done in the first place