### PR TITLE
feat: new cols in intermediate table

### DIFF
--- a/data-pipeline/common/page_revision_metadata.py
+++ b/data-pipeline/common/page_revision_metadata.py
@@ -1,20 +1,20 @@
 class PageRevisionMetadata:
     def __init__(
         self,
-        revision_count: int,
+        edit_count: int,
         editor_count: int,
         revert_count: int,
-        net_bytes_change: int,
-        total_bytes_reverted: int
+        total_bytes_changed: int,
+        total_bytes_reverted: int,
     ):
-        self.revision_count = revision_count
+        self.edit_count = edit_count
         self.editor_count = editor_count
         self.revert_count = revert_count
-        self.net_bytes_change = net_bytes_change
+        self.total_bytes_changed = total_bytes_changed
         self.total_bytes_reverted = total_bytes_reverted
 
     def __str__(self) -> str:
-        return f"revision_count={self.revision_count}, editor_count={self.editor_count}, revert_count={self.revert_count}, net_bytes_change={self.net_bytes_change}"
+        return f"edit_count={self.edit_count}, editor_count={self.editor_count}, revert_count={self.revert_count}, total_bytes_changed={self.total_bytes_changed}, total_bytes_reverted={self.total_bytes_reverted}"
 
     def __repr__(self) -> str:
         return f"PageRevisionMetadata({self})"

--- a/data-pipeline/common/page_revision_metadata.py
+++ b/data-pipeline/common/page_revision_metadata.py
@@ -11,6 +11,7 @@ class PageRevisionMetadata:
         self.editor_count = editor_count
         self.revert_count = revert_count
         self.net_bytes_change = net_bytes_change
+        self.revert_bytes_change = revert_bytes_change
 
     def __str__(self) -> str:
         return f"revision_count={self.revision_count}, editor_count={self.editor_count}, revert_count={self.revert_count}, net_bytes_change={self.net_bytes_change}"

--- a/data-pipeline/common/page_revision_metadata.py
+++ b/data-pipeline/common/page_revision_metadata.py
@@ -5,13 +5,13 @@ class PageRevisionMetadata:
         editor_count: int,
         revert_count: int,
         net_bytes_change: int,
-        revert_bytes_change: int
+        total_bytes_reverted: int
     ):
         self.revision_count = revision_count
         self.editor_count = editor_count
         self.revert_count = revert_count
         self.net_bytes_change = net_bytes_change
-        self.revert_bytes_change = revert_bytes_change
+        self.total_bytes_reverted = total_bytes_reverted
 
     def __str__(self) -> str:
         return f"revision_count={self.revision_count}, editor_count={self.editor_count}, revert_count={self.revert_count}, net_bytes_change={self.net_bytes_change}"

--- a/data-pipeline/common/page_revision_metadata.py
+++ b/data-pipeline/common/page_revision_metadata.py
@@ -5,6 +5,7 @@ class PageRevisionMetadata:
         editor_count: int,
         revert_count: int,
         net_bytes_change: int,
+        revert_bytes_change: int
     ):
         self.revision_count = revision_count
         self.editor_count = editor_count

--- a/data-pipeline/ingestion/data_sources/page_revision_data_source.py
+++ b/data-pipeline/ingestion/data_sources/page_revision_data_source.py
@@ -120,7 +120,7 @@ class PageRevisionDumpFile(PageRevisionDataSource):
                     revert_count=sum(
                         "revert" in entry["revision_tags"] for entry in entries
                     ),
-                    revert_bytes_change=sum(
+                    total_bytes_reverted=sum(
                         int(
                             abs(entry["revision_text_bytes_diff"])
                             if "revert" in entry["revision_tags"] and entry["revision_text_bytes_diff"].isnumeric()

--- a/data-pipeline/ingestion/data_sources/page_revision_data_source.py
+++ b/data-pipeline/ingestion/data_sources/page_revision_data_source.py
@@ -90,8 +90,9 @@ class PageRevisionDumpFile(PageRevisionDataSource):
                     aggregated_data[date][page] = []
 
                 aggregated_data[date][page].append(
-                    {
-                        "event_user_id": cols[self.col_name_to_index["event_user_id"]],
+                    {   
+                        # using event_user_text_historical as some revisions are made by editors with no id but a name
+                        "event_user_text_historical": cols[self.col_name_to_index["event_user_text_historical"]],
                         "revision_text_bytes_diff": cols[
                             self.col_name_to_index["revision_text_bytes_diff"]
                         ],
@@ -106,7 +107,7 @@ class PageRevisionDumpFile(PageRevisionDataSource):
 
                 self.dates_data[date][page] = PageRevisionMetadata(
                     revision_count=len(entries),
-                    editor_count=len(set(entry["event_user_id"] for entry in entries)),
+                    editor_count=len(set(entry["event_user_text_historical"] for entry in entries)),
                     # net_bytes_change is the total number of bytes changed in the day
                     net_bytes_change=sum(
                         int(

--- a/data-pipeline/ingestion/data_sources/page_revision_data_source.py
+++ b/data-pipeline/ingestion/data_sources/page_revision_data_source.py
@@ -92,8 +92,8 @@ class PageRevisionDumpFile(PageRevisionDataSource):
                 aggregated_data[date][page].append(
                     {
                         "event_user_id": cols[self.col_name_to_index["event_user_id"]],
-                        "revision_text_bytes": cols[
-                            self.col_name_to_index["revision_text_bytes"]
+                        "revision_text_bytes_diff": cols[
+                            self.col_name_to_index["revision_text_bytes_diff"]
                         ],
                         "revision_tags": cols[self.col_name_to_index["revision_tags"]],
                     }
@@ -107,11 +107,11 @@ class PageRevisionDumpFile(PageRevisionDataSource):
                 self.dates_data[date][page] = PageRevisionMetadata(
                     revision_count=len(entries),
                     editor_count=len(set(entry["event_user_id"] for entry in entries)),
-                    # net_bytes_change is the sum of all revision_text_bytes, not a total delta
+                    # net_bytes_change is the total number of bytes changed in the day
                     net_bytes_change=sum(
                         int(
-                            entry["revision_text_bytes"]
-                            if entry["revision_text_bytes"].isnumeric()
+                            entry["revision_text_bytes_diff"]
+                            if entry["revision_text_bytes_diff"].isnumeric()
                             else 0
                         )
                         for entry in entries
@@ -119,6 +119,14 @@ class PageRevisionDumpFile(PageRevisionDataSource):
                     revert_count=sum(
                         "revert" in entry["revision_tags"] for entry in entries
                     ),
+                    revert_bytes_change=sum(
+                        int(
+                            abs(entry["revision_text_bytes_diff"])
+                            if "revert" in entry["revision_tags"] and entry["revision_text_bytes_diff"].isnumeric()
+                            else 0
+                        ) 
+                        for entry in entries
+                    )
                 )
 
     def get_page_revision_metadata(
@@ -135,5 +143,5 @@ class PageRevisionDumpFile(PageRevisionDataSource):
 
         future: Future[PageRevisionMetadata] = Future()
         res = date_data.get(page)
-        future.set_result(PageRevisionMetadata(0, 0, 0, 0) if res is None else res)
+        future.set_result(PageRevisionMetadata(0, 0, 0, 0, 0) if res is None else res)
         return future

--- a/data-pipeline/ingestion/data_sources/page_revision_data_source.py
+++ b/data-pipeline/ingestion/data_sources/page_revision_data_source.py
@@ -106,10 +106,9 @@ class PageRevisionDumpFile(PageRevisionDataSource):
                     self.dates_data[date] = {}
 
                 self.dates_data[date][page] = PageRevisionMetadata(
-                    revision_count=len(entries),
+                    edit_count=len(entries),
                     editor_count=len(set(entry["event_user_text_historical"] for entry in entries)),
-                    # net_bytes_change is the total number of bytes changed in the day
-                    net_bytes_change=sum(
+                    total_bytes_changed=sum(
                         int(
                             entry["revision_text_bytes_diff"]
                             if entry["revision_text_bytes_diff"].isnumeric()

--- a/data-pipeline/ingestion/data_sources/page_revision_data_source.py
+++ b/data-pipeline/ingestion/data_sources/page_revision_data_source.py
@@ -120,12 +120,14 @@ class PageRevisionDumpFile(PageRevisionDataSource):
                     revert_count=sum(
                         "revert" in entry["revision_tags"] for entry in entries
                     ),
-                    total_bytes_reverted=sum(
-                        int(
-                            abs(entry["revision_text_bytes_diff"])
-                            if "revert" in entry["revision_tags"] and entry["revision_text_bytes_diff"].isnumeric()
-                            else 0
-                        ) 
+                    total_bytes_reverted=
+                        sum(
+                            abs(
+                                int(entry["revision_text_bytes_diff"]
+                                if "revert" in entry["revision_tags"] and entry["revision_text_bytes_diff"].isnumeric()
+                                else 0
+                                )
+                            )
                         for entry in entries
                     )
                 )

--- a/data-pipeline/ingestion/ingest.py
+++ b/data-pipeline/ingestion/ingest.py
@@ -16,6 +16,7 @@ from ingestion.data_sources.page_name_data_source import (
     PageNameWikiMediaAPI,
 )
 from ingestion.wikimedia_dumps.dump_manager import DumpManager
+from sql.intermediate_table_data import recreate_intermediate_table
 
 
 def ingest_dates(
@@ -26,10 +27,14 @@ def ingest_dates(
     edit_source_str: str,
     batch_size: int,
     batch_wait: float,
+    recreate_table: bool = False,
 ) -> None:
     wikipedia_data_accessor = WikipediaDataAccessor(
         logger, "PLINY_BIGQUERY_SERVICE_ACCOUNT", buffer_size=batch_size * 10
     )
+
+    if recreate_table:
+        recreate_intermediate_table(wikipedia_data_accessor)
 
     dump_manager = DumpManager(logger, "dumps", date_range)
 

--- a/data-pipeline/ingestion/mediawiki_api/mediawiki_api.py
+++ b/data-pipeline/ingestion/mediawiki_api/mediawiki_api.py
@@ -106,18 +106,29 @@ class MediaWikiAPI:
 
             # Process revisions into three integers
             revision_count = len(revisions)
-            editor_count = len(set(revision["userid"] for revision in revisions))
+            editor_count = len(set(revision["userid"] for revision in revisions)) #TODO: unsure if userid here can be empty like dump
             revert_count = sum(
                 "mw-reverted" in revision["tags"] for revision in revisions
             )
             net_bytes_change = (
                 (revisions[-1]["size"] - revisions[0]["size"]) if revisions else 0
             )  # FIXME: this doesnt include the diff from the first revision
+            total_bytes_reverted = (
+                sum(
+                    int(
+                        revision["diff"]
+                        if "mw-reverted" in revision["tags"] and revision["diff"].isnumeric() 
+                        else 0
+                    )
+                    for revision in revisions
+                    )
+            )            
             return PageRevisionMetadata(
                 revision_count=revision_count,
                 editor_count=editor_count,
                 revert_count=revert_count,
                 net_bytes_change=net_bytes_change,
+                total_bytes_reverted=total_bytes_reverted
             )
 
         return self.executor.submit(helper_loop, page_name)

--- a/data-pipeline/ingestion/mediawiki_api/mediawiki_api.py
+++ b/data-pipeline/ingestion/mediawiki_api/mediawiki_api.py
@@ -115,11 +115,12 @@ class MediaWikiAPI:
             )  # FIXME: this doesnt include the diff from the first revision
             total_bytes_reverted = (
                 sum(
-                    int(
+                    abs(
+                        int(
                         revision["diff"]
                         if "mw-reverted" in revision["tags"] and revision["diff"].isnumeric() 
                         else 0
-                    )
+                    ))
                     for revision in revisions
                     )
             )            

--- a/data-pipeline/ingestion/processor/intermediate_table_processor.py
+++ b/data-pipeline/ingestion/processor/intermediate_table_processor.py
@@ -49,6 +49,7 @@ class IntermediateTableProcessor:
                 data[page].editor_count = revision_metadata.editor_count
                 data[page].revert_count = revision_metadata.revert_count
                 data[page].net_bytes_change = revision_metadata.net_bytes_change
+                data[page].total_bytes_reverted = revision_metadata.total_bytes_reverted
             except Exception as e:
                 self.logger.error(
                     f"Error processing revision future for page {page}: {e}",
@@ -67,6 +68,7 @@ class IntermediateTableProcessor:
                     "net_bytes_change": intermediate_table_row.net_bytes_change,
                     "editor_count": intermediate_table_row.editor_count,
                     "revert_count": intermediate_table_row.revert_count,
+                    "total_bytes_reverted": intermediate_table_row.total_bytes_reverted
                 }
             )
 

--- a/data-pipeline/ingestion/processor/intermediate_table_processor.py
+++ b/data-pipeline/ingestion/processor/intermediate_table_processor.py
@@ -45,10 +45,10 @@ class IntermediateTableProcessor:
         for page, revision_future in revision_futures.items():
             try:
                 revision_metadata = revision_future.result()
-                data[page].revision_count = revision_metadata.revision_count
+                data[page].edit_count = revision_metadata.edit_count
                 data[page].editor_count = revision_metadata.editor_count
                 data[page].revert_count = revision_metadata.revert_count
-                data[page].net_bytes_change = revision_metadata.net_bytes_change
+                data[page].total_bytes_changed = revision_metadata.total_bytes_changed
                 data[page].total_bytes_reverted = revision_metadata.total_bytes_reverted
             except Exception as e:
                 self.logger.error(
@@ -64,11 +64,11 @@ class IntermediateTableProcessor:
                     "date": date.to_py_date().isoformat(),
                     "page_name": page_name,
                     "view_count": intermediate_table_row.view_count,
-                    "revision_count": intermediate_table_row.revision_count,
-                    "net_bytes_change": intermediate_table_row.net_bytes_change,
+                    "edit_count": intermediate_table_row.edit_count,
+                    "total_bytes_changed": intermediate_table_row.total_bytes_changed,
                     "editor_count": intermediate_table_row.editor_count,
                     "revert_count": intermediate_table_row.revert_count,
-                    "total_bytes_reverted": intermediate_table_row.total_bytes_reverted
+                    "total_bytes_reverted": intermediate_table_row.total_bytes_reverted,
                 }
             )
 

--- a/data-pipeline/main.py
+++ b/data-pipeline/main.py
@@ -60,6 +60,11 @@ def parse_args() -> argparse.Namespace:
         default=0.0,
         help="Wait time between ingest batches in seconds (default: 0.0)",
     )
+    ingest_group.add_argument(
+        "--recreate-table",
+        action="store_true",
+        help="Recreate the table with the new INTERMEDIATE_TABLE_SCHEMA. Use this carefully",
+    )
 
     # Score group
     score_group = parser.add_argument_group("score arguments")
@@ -145,6 +150,16 @@ if __name__ == "__main__":
         ingest_batch_wait: float = args.ingest_batch_wait
 
         date_range = DateRange(ingest_start, ingest_end)
+
+        if args.recreate_table:
+            print(
+                "Recreate table argument passed. Please type 'I am sure' to confirm the operation. ONLY DO THIS IF YOU WANT TO DELETE ALL EXISTING DATA:"
+            )
+            confirm = input()
+            if confirm != "I am sure":
+                print("Aborting operation")
+                exit(1)
+
         ingest_dates(
             logger=logger,
             date_range=date_range,
@@ -153,6 +168,7 @@ if __name__ == "__main__":
             edit_source_str=ingest_edit_source,
             batch_size=ingest_batch_size,
             batch_wait=ingest_batch_wait,
+            recreate_table=args.recreate_table,
         )
 
     score: bool = args.score

--- a/data-pipeline/scoring/scorer/final_table_scorer.py
+++ b/data-pipeline/scoring/scorer/final_table_scorer.py
@@ -41,10 +41,10 @@ class FinalTableScorer:
 
         query = f"""
             INSERT INTO wikipedia_data.top_vandalism_final_table (
-                select date, page_name as 'article', log(revert_count) + log(net_bytes_change) as 'score' from (
-                    SELECT page_name, revert_count, net_bytes_change, date
+                select date, page_name as 'article', log(revert_count) + log(total_bytes_changed) as 'score' from (
+                    SELECT page_name, revert_count, total_bytes_changed, date
                     FROM wikipedia_data. intermediate_table_sep
-                    where date={self._get_sql_date(date)} and revert_count > 0 and net_bytes_change > 0
+                    where date={self._get_sql_date(date)} and revert_count > 0 and total_bytes_changed > 0
                 )
                 order by score desc
                 limit {self.insert_limit}

--- a/data-pipeline/sql/intermediate_table_data.py
+++ b/data-pipeline/sql/intermediate_table_data.py
@@ -8,6 +8,7 @@ INTEMEDIATE_TABLE_SCHEMA = [
     SchemaField("net_bytes_change", "INT64", mode="REQUIRED"),
     SchemaField("editor_count", "INT64", mode="REQUIRED"),
     SchemaField("revert_count", "INT64", mode="REQUIRED"),
+    SchemaField("total_bytes_reverted", "INT64", mode="REQUIRED"),
 ]
 
 
@@ -19,9 +20,10 @@ class IntermediateTableRow:
         self.net_bytes_change = 0
         self.editor_count = 0
         self.revert_count = 0
+        self.total_bytes_reverted = 0
 
     def __str__(self) -> str:
-        return f"{self.page_name}: view_count={self.view_count}, revision_count={self.revision_count}, net_bytes_change={self.net_bytes_change}, editor_count={self.editor_count}, revert_count={self.revert_count}"
+        return f"{self.page_name}: view_count={self.view_count}, revision_count={self.revision_count}, net_bytes_change={self.net_bytes_change}, editor_count={self.editor_count}, revert_count={self.revert_count} total_bytes_reverted={self.total_bytes_reverted}"
 
     def __repr__(self) -> str:
         return f"IntermediateTableRow({self})"

--- a/data-pipeline/sql/intermediate_table_data.py
+++ b/data-pipeline/sql/intermediate_table_data.py
@@ -1,29 +1,37 @@
 from google.cloud.bigquery.schema import SchemaField
+from sql.wikipedia_data_accessor import WikipediaDataAccessor
 
-INTEMEDIATE_TABLE_SCHEMA = [
+INTERMEDIATE_TABLE_SCHEMA = [
     SchemaField("date", "DATE", mode="REQUIRED"),
     SchemaField("page_name", "STRING", mode="REQUIRED"),
     SchemaField("view_count", "INT64", mode="REQUIRED"),
-    SchemaField("revision_count", "INT64", mode="REQUIRED"),
-    SchemaField("net_bytes_change", "INT64", mode="REQUIRED"),
-    SchemaField("editor_count", "INT64", mode="REQUIRED"),
+    SchemaField("edit_count", "INT64", mode="REQUIRED"),
     SchemaField("revert_count", "INT64", mode="REQUIRED"),
+    SchemaField("editor_count", "INT64", mode="REQUIRED"),
+    SchemaField("total_bytes_changed", "INT64", mode="REQUIRED"),
     SchemaField("total_bytes_reverted", "INT64", mode="REQUIRED"),
 ]
+
+
+def recreate_intermediate_table(wikipedia_data_accessor: WikipediaDataAccessor) -> None:
+    wikipedia_data_accessor.delete_table("intermediate_table")
+    wikipedia_data_accessor.create_table(
+        "intermediate_table", INTERMEDIATE_TABLE_SCHEMA
+    )
 
 
 class IntermediateTableRow:
     def __init__(self, page_name: str):
         self.page_name = page_name
         self.view_count = 0
-        self.revision_count = 0
-        self.net_bytes_change = 0
+        self.edit_count = 0
+        self.total_bytes_changed = 0
         self.editor_count = 0
         self.revert_count = 0
         self.total_bytes_reverted = 0
 
     def __str__(self) -> str:
-        return f"{self.page_name}: view_count={self.view_count}, revision_count={self.revision_count}, net_bytes_change={self.net_bytes_change}, editor_count={self.editor_count}, revert_count={self.revert_count} total_bytes_reverted={self.total_bytes_reverted}"
+        return f"{self.page_name}: view_count={self.view_count}, edit_count={self.edit_count}, total_bytes_changed={self.total_bytes_changed}, editor_count={self.editor_count}, revert_count={self.revert_count} total_bytes_reverted={self.total_bytes_reverted}"
 
     def __repr__(self) -> str:
         return f"IntermediateTableRow({self})"


### PR DESCRIPTION
Took a look at our trends to see what columns we need to add to the table, from what I could tell, I think these were the main changes necessary:

- a fix of our "net_bytes_diff" as it was just taking the byte size of the page after the revision
- a "revert_bytes_change", computing the total number of bytes that were reverted back and forth (sum of the size of all revert edits) -> this is for our vandalism metric
- updated editor count to try and account for editor_count = 0; using editor names instead of ids, as a lot of the revisions don't have editor_id populated for some reason