### PR TITLE
add mock trend 

### DIFF
--- a/backend/main.go
+++ b/backend/main.go
@@ -16,6 +16,7 @@ func main() {
 
 	router := gin.Default()
 	router.GET("/topViews/:date/:limit", getTopViews)
+	router.GET("/mock/:date/:limit", getMock)
 	router.Run("localhost:8080")
 }
 
@@ -33,4 +34,20 @@ func getTopViews(c *gin.Context) {
 		return
 	}
 	c.IndentedJSON(http.StatusOK, views)
+}
+
+func getMock(c *gin.Context) {
+	date := c.Param("date")
+	limit, err := strconv.Atoi(c.Param("limit"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid limit parameter"})
+		return
+	}
+
+	mock, err := fetchMockFromBigQuery(date, limit)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.IndentedJSON(http.StatusOK, mock)
 }

--- a/backend/models.go
+++ b/backend/models.go
@@ -7,3 +7,8 @@ type TopViewsData struct {
 	PageName  string     `bigquery:"page_name" json:"page_name"`
 	ViewCount int        `bigquery:"view_count" json:"view_count"`
 }
+
+type MockData struct {
+	Date     civil.Date `bigquery:"date" json:"date"`
+	PageName string     `bigquery:"page_name" json:"page_name"`
+}

--- a/backend/queries/fetch_mock.sql
+++ b/backend/queries/fetch_mock.sql
@@ -1,0 +1,4 @@
+SELECT date, page_name
+FROM wikipedia_data.mock_final_table
+WHERE date={{date}}
+LIMIT {{limit}};

--- a/data-pipeline/scoring/queries/insert_mock.sql
+++ b/data-pipeline/scoring/queries/insert_mock.sql
@@ -1,0 +1,9 @@
+INSERT INTO wikipedia_data.mock_final_table (
+    SELECT date, page_name
+    FROM (
+        SELECT date, page_name
+        FROM wikipedia_data.intermediate_table
+        where date={{date}}
+    )
+    limit {{limit}}
+)

--- a/data-pipeline/scoring/score.py
+++ b/data-pipeline/scoring/score.py
@@ -12,10 +12,17 @@ FINAL_TABLE_SCHEMAS: dict[str, list[SchemaField]] = {
         SchemaField("date", "DATE", mode="REQUIRED"),
         SchemaField("page_name", "STRING", mode="REQUIRED"),
         SchemaField("view_count", "INT64", mode="REQUIRED"),
-    ]
+    ],
+    "mock_final_table": [
+        SchemaField("date", "DATE", mode="REQUIRED"),
+        SchemaField("page_name", "STRING", mode="REQUIRED"),
+    ],
 }
 
-def score_dates(logger: Logger, date_range: DateRange, recreate_final_tables: bool) -> None:
+
+def score_dates(
+    logger: Logger, date_range: DateRange, recreate_final_tables: bool
+) -> None:
     wikipedia_data_accessor = WikipediaDataAccessor(
         logger, "PLINY_BIGQUERY_SERVICE_ACCOUNT", buffer_size=1
     )
@@ -25,8 +32,11 @@ def score_dates(logger: Logger, date_range: DateRange, recreate_final_tables: bo
         logger.info("Recreating final tables", Component.CORE)
         for table_name, schema in FINAL_TABLE_SCHEMAS.items():
             wikipedia_data_accessor.delete_table(table_name)
-            wikipedia_data_accessor.create_table(table_name, schema, partition_on_date=True)
+            wikipedia_data_accessor.create_table(
+                table_name, schema, partition_on_date=True
+            )
 
     for date in date_range:
         logger.info(f"Starting scoring for date {date}", Component.CORE)
         scorer.compute_top_views(date)
+        scorer.compute_mock(date)

--- a/data-pipeline/scoring/scorer/final_table_scorer.py
+++ b/data-pipeline/scoring/scorer/final_table_scorer.py
@@ -50,3 +50,14 @@ class FinalTableScorer:
         }
 
         self._run_query(file_name, params)
+
+    def compute_mock(self, date: Date) -> None:
+        self.logger.info(f"Computing mock for {date}", Component.DATABASE)
+
+        file_name = "insert_mock.sql"
+        params = {
+            "date": self._get_sql_date(date),
+            "limit": str(self.insert_limit),
+        }
+
+        self._run_query(file_name, params)


### PR DESCRIPTION
To run python, run `python3 ./data-pipeline/main.py --score --score-start 2024-09-01 --score-end 2024-09-01 --recreate-final-tables`. All of september is ingested, so feel free to use any date from 2024-09-01 to 2024-09-30.

Then you can run go on localhost by following the instructions in the README, and then curling the new endpoint you make.